### PR TITLE
Allow manual fee/Kb setting

### DIFF
--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -95,6 +95,16 @@ class BlockchainInterface(object):
         required for inclusion in the next N blocks.
 	'''
 
+    def fee_per_kb_has_been_manually_set(self, N):
+        '''if the 'block' target is higher than 144, interpret it
+        as manually set fee/Kb.
+    '''
+        if N > 144:
+            return True
+        else:
+            return False
+
+
 class ElectrumWalletInterface(BlockchainInterface): #pragma: no cover
     """A pseudo-blockchain interface using the existing 
     Electrum server connection in an Electrum wallet.
@@ -180,6 +190,8 @@ class ElectrumWalletInterface(BlockchainInterface): #pragma: no cover
         return result
 
     def estimate_fee_per_kb(self, N):
+        if super(ElectrumWalletInterface, self).fee_per_kb_has_been_manually_set(N):
+            return N
         fee = self.wallet.network.synchronous_get(('blockchain.estimatefee', [N]
                                                   ))
         log.debug("Got fee: " + str(fee))
@@ -769,11 +781,17 @@ class BitcoinCoreInterface(BlockchainInterface):
         return result
 
     def estimate_fee_per_kb(self, N):
+        if super(BitcoinCoreInterface, self).fee_per_kb_has_been_manually_set(N):
+            return N
         estimate = int(Decimal(1e8) * Decimal(self.rpc('estimatefee', [N])))
+        if (N == 1) and (estimate < 0):
+            # Special bitcoin core case: sometimes the highest priority
+            # cannot be estimated in that case the 2nd highest priority
+            # should be used instead of falling back to hardcoded values
+            estimate = Decimal(1e8) * Decimal(self.rpc('estimatefee', [N+1]))
         if estimate < 0:
-            #This occurs when Core has insufficient data to estimate.
-            #TODO anything better than a hardcoded default?
-            return 30000
+            # This occurs when Core has insufficient data to estimate.
+            return 100000
         else:
             return estimate
 

--- a/jmclient/jmclient/blockchaininterface.py
+++ b/jmclient/jmclient/blockchaininterface.py
@@ -788,7 +788,7 @@ class BitcoinCoreInterface(BlockchainInterface):
             # Special bitcoin core case: sometimes the highest priority
             # cannot be estimated in that case the 2nd highest priority
             # should be used instead of falling back to hardcoded values
-            estimate = Decimal(1e8) * Decimal(self.rpc('estimatefee', [N+1]))
+            estimate = int(Decimal(1e8) * Decimal(self.rpc('estimatefee', [N+1])))
         if estimate < 0:
             # This occurs when Core has insufficient data to estimate.
             return 100000

--- a/jmclient/jmclient/configure.py
+++ b/jmclient/jmclient/configure.py
@@ -157,15 +157,18 @@ merge_algorithm = default
 # per kB are needed to get in one of the next N blocks, N set here
 # as the value of 'tx_fees'. This estimate is high if you set N=1, 
 # so we choose N=3 for a more reasonable figure,
-# as our default. Note that for clients not using a local blockchain
-# instance, we retrieve an estimate from the API at blockcypher.com, currently.
+# as our default.
+# You can also set your own fee/kb: any number higher than 144 will
+# be interpreted as the fee in satoshi per kB that you wish to use
+# example: N=30000 will use 30000 sat/kB as a fee, while N=5
+# will use the estimate from your selected blockchain source
 tx_fees = 3
-# For users getting transaction fee estimates over an API
-# (currently blockcypher, could be others), place a sanity
-# check limit on the satoshis-per-kB to be paid. This limit
-# is also applied to users using Core, even though Core has its
-# own sanity check limit, which is currently 1,000,000 satoshis.
-absurd_fee_per_kb = 150000
+# For users getting transaction fee estimates over an API,
+# place a sanity check limit on the satoshis-per-kB to be paid.
+# This limit is also applied to users using Core, even though
+# Core has its own sanity check limit, which is currently
+# 1,000,000 satoshis.
+absurd_fee_per_kb = 350000
 # the range of confirmations passed to the `listunspent` bitcoind RPC call
 # 1st value is the inclusive minimum, defaults to one confirmation
 # 2nd value is the exclusive maximum, defaults to most-positive-bignum (Google Me!)


### PR DESCRIPTION
Ported the change from the old joinmarket, tested successfully.

Additional changes:
- absurd_fee_per_kb increased to 350k sat/Kb
- default fall-back fee if estimation does not work increased to 100k sat/Kb